### PR TITLE
fix: [ui] add padding to password checkbox

### DIFF
--- a/src/dde-control-center-plugins/wallpapersetting/screensaver/idletime.cpp
+++ b/src/dde-control-center-plugins/wallpapersetting/screensaver/idletime.cpp
@@ -32,6 +32,7 @@ IdleTime::IdleTime(QWidget *parent) : QWidget(parent)
 
     pwdCheck = new QCheckBox(tr("Require a password on wakeup"), bkg);
     pwdCheck->setFixedHeight(combox->height());
+    pwdCheck->setStyleSheet("QCheckBox { padding-left: 10px; }");
     bgGpLayout->addWidget(pwdCheck);
 
     connect(pwdCheck, &QCheckBox::clicked, this, &IdleTime::setIsLock);


### PR DESCRIPTION
- Add left padding to the password checkbox in the screensaver settings

Log: [ui] add padding to password checkbox
Bug: https://pms.uniontech.com/bug-view-251761.html