### PR TITLE
fix(wallpapersetting): optimize thread management and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 
 CMakeLists.txt.user
+
+
+build*
+
+# vscode
+.vscode
+
+

--- a/src/dde-control-center-plugins/wallpapersetting/common/previewwidget.h
+++ b/src/dde-control-center-plugins/wallpapersetting/common/previewwidget.h
@@ -23,6 +23,7 @@ public:
         qreal ratio;
     };
     explicit PixmapProducer(QObject *parent);
+    ~PixmapProducer();
     void append(const PixmapInfo &);
     void stop();
     void launch();


### PR DESCRIPTION
- Add destructor to PixmapProducer to ensure proper thread termination
- Remove unnecessary thread stop and wait logic from PreviewWidget
- Update .gitignore to exclude build files and VSCode settings

Log: fix(wallpapersetting): optimize thread management and cleanup
Bug: https://pms.uniontech.com/bug-view-310913.html

## Summary by Sourcery

Optimize thread management and cleanup in the wallpaper settings component by improving thread termination and removing unnecessary synchronization logic.

Bug Fixes:
- Improve thread management in PixmapProducer to ensure proper thread termination and prevent potential resource leaks

Enhancements:
- Simplify thread stopping mechanism in PreviewWidget
- Add destructor to PixmapProducer to handle thread cleanup

Chores:
- Update .gitignore to exclude build files and VSCode settings