### PR TITLE
feat(wallpapersetting): implement thumbnail caching for wallpapers an…

### DIFF
--- a/src/dde-control-center-plugins/wallpapersetting/common/thumbnailcacheutils.cpp
+++ b/src/dde-control-center-plugins/wallpapersetting/common/thumbnailcacheutils.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "thumbnailcacheutils.h"
+
+#include <QFile>
+#include <QIODevice>
+#include <QCryptographicHash>
+#include <QStandardPaths>
+#include <QDir>
+#include <QDebug> 
+
+namespace ThumbnailCacheUtils {
+
+QString calculateFileHash(const QString &filePath) {
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning() << "Failed to open file for hashing:" << filePath;
+        return QString(); // 返回空 QString 表示失败
+    }
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    if (!file.atEnd()) { // 优化：如果文件为空，不需要读取
+         constexpr qint64 bufferSize = 8192;
+         while (!file.atEnd()) {
+             hash.addData(file.read(bufferSize));
+         }
+    }
+    file.close();
+    return QString::fromLatin1(hash.result().toHex()); // 明确使用 fromLatin1
+}
+
+QString getThumbnailCachePath(const QString &originalPath, const QSize &size) {
+    // 优先使用 CacheLocation，如果不可写，尝试回退到 GenericCacheLocation
+    QString cacheBaseDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (cacheBaseDir.isEmpty()) {
+         cacheBaseDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
+         if(cacheBaseDir.isEmpty()){
+             qWarning() << "Cannot find writable cache location!";
+             // 在极端情况下，可能返回一个无效路径，调用者需要处理
+             return QString();
+         }
+    }
+
+    QString cacheDir = cacheBaseDir + QDir::separator() + THUMBNAIL_CACHE_DIR_NAME;
+    QDir dir; // 创建 QDir 对象来处理路径创建
+    if (!dir.exists(cacheDir)) {
+        if (!dir.mkpath(cacheDir)) {
+             qWarning() << "Failed to create thumbnail cache directory:" << cacheDir;
+             // 即使创建失败也继续，后续保存会失败，但尝试加载可能仍然有用（如果目录已存在但权限有问题）
+        }
+    }
+
+    QString hash = calculateFileHash(originalPath);
+    if (hash.isEmpty()) {
+        // 如果计算哈希失败，使用路径本身的哈希作为备选
+        qWarning() << "Failed to calculate file hash for:" << originalPath << "Using path hash as fallback.";
+        hash = QString::fromLatin1(QCryptographicHash::hash(originalPath.toUtf8(), QCryptographicHash::Md5).toHex());
+    }
+
+    // 使用 PNG 格式，文件名包含哈希和尺寸
+    QString fileName = QStringLiteral("%1_%2x%3.png").arg(hash).arg(size.width()).arg(size.height());
+    return QDir(cacheDir).absoluteFilePath(fileName); // 使用 QDir 确保路径正确
+}
+
+} // namespace ThumbnailCacheUtils

--- a/src/dde-control-center-plugins/wallpapersetting/common/thumbnailcacheutils.h
+++ b/src/dde-control-center-plugins/wallpapersetting/common/thumbnailcacheutils.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef THUMBNAILCACHEUTILS_H
+#define THUMBNAILCACHEUTILS_H
+
+#include <QString>
+#include <QSize>
+
+namespace ThumbnailCacheUtils {
+
+// 缓存目录的名称
+const QString THUMBNAIL_CACHE_DIR_NAME = QStringLiteral("thumbnails");
+
+/**
+ * @brief 计算文件内容的 MD5 哈希值
+ * @param filePath 文件路径
+ * @return 文件的 MD5 哈希值 (十六进制字符串)，如果失败则返回空字符串
+ */
+QString calculateFileHash(const QString &filePath);
+
+/**
+ * @brief 获取缩略图的缓存文件路径
+ * @param originalPath 原始文件的路径
+ * @param size 缩略图的目标尺寸
+ * @return 完整的缓存文件路径
+ */
+QString getThumbnailCachePath(const QString &originalPath, const QSize &size);
+
+} // namespace ThumbnailCacheUtils
+
+#endif // THUMBNAILCACHEUTILS_H


### PR DESCRIPTION
…d screensavers

- Add thumbnail cache utils to calculate file hashes and get cache paths
- Integrate cache loading and saving in wallpaper and screensaver thumbnail generation
- Improve error handling and logging for thumbnail operations
- Optimize thumbnail generation process by checking cache first

Log: feat(wallpapersetting): implement thumbnail caching for wallpapers and screensavers
Bug: https://pms.uniontech.com/bug-view-293799.html

## Summary by Sourcery

Implement thumbnail caching mechanism for wallpapers and screensavers to improve performance and reduce redundant image processing

New Features:
- Add a new thumbnail caching utility to generate and manage cached thumbnails for wallpapers and screensavers

Enhancements:
- Optimize thumbnail generation by implementing cache lookup before image processing
- Improve error handling and logging for thumbnail operations

Chores:
- Create a new utility class ThumbnailCacheUtils to handle thumbnail caching operations