### PR TITLE
feat: Add desktop wallpaper filling method options

### DIFF
--- a/src/dde-control-center-plugins/wallpapersetting/translations/dcc-wallpapersetting-plugin.ts
+++ b/src/dde-control-center-plugins/wallpapersetting/translations/dcc-wallpapersetting-plugin.ts
@@ -32,6 +32,39 @@
     </message>
 </context>
 <context>
+    <name>dfm_wallpapersetting::FillstylesCombox</name>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="20"/>
+        <source>Fill Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="23"/>
+        <source>Fill</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="24"/>
+        <source>Fit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="25"/>
+        <source>Stretch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="26"/>
+        <source>Tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="27"/>
+        <source>Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>dfm_wallpapersetting::IdleTime</name>
     <message>
         <location filename="../screensaver/idletime.cpp" line="30"/>
@@ -186,11 +219,16 @@
     </message>
     <message>
         <location filename="../wallpapersettingplugin.cpp" line="108"/>
+        <source>Fill Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../wallpapersettingplugin.cpp" line="109"/>
         <source>Picture</source>
         <translation>Picture</translation>
     </message>
     <message>
-        <location filename="../wallpapersettingplugin.cpp" line="109"/>
+        <location filename="../wallpapersettingplugin.cpp" line="110"/>
         <source>Solid Color</source>
         <translation>Solid Color</translation>
     </message>
@@ -198,27 +236,27 @@
 <context>
     <name>dfm_wallpapersetting::WallpaperWindow</name>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="250"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="258"/>
         <source>Select Wallpaper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="252"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="260"/>
         <source>Images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="368"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="376"/>
         <source>Set to lock screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="369"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="377"/>
         <source>Set to desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="404"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="412"/>
         <source>This system wallpaper is locked. Please contact your admin.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/dde-control-center-plugins/wallpapersetting/translations/dcc-wallpapersetting-plugin_zh_CN.ts
+++ b/src/dde-control-center-plugins/wallpapersetting/translations/dcc-wallpapersetting-plugin_zh_CN.ts
@@ -32,6 +32,41 @@
     </message>
 </context>
 <context>
+    <name>dfm_wallpapersetting::FillstylesCombox</name>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="20"/>
+        <source>Fill Style</source>
+        <translation>填充方式</translation>
+        <extra-child_page>WallpaperSetting</extra-child_page>
+        <extra-contents_path>/personalization/WallpaperSetting</extra-contents_path>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="23"/>
+        <source>Fill</source>
+        <translation>填充</translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="24"/>
+        <source>Fit</source>
+        <translation>适应</translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="25"/>
+        <source>Stretch</source>
+        <translation>拉伸</translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="26"/>
+        <source>Tile</source>
+        <translation>平铺</translation>
+    </message>
+    <message>
+        <location filename="../wallpaper/fillstylescombox.cpp" line="27"/>
+        <source>Center</source>
+        <translation>居中</translation>
+    </message>
+</context>
+<context>
     <name>dfm_wallpapersetting::IdleTime</name>
     <message>
         <location filename="../screensaver/idletime.cpp" line="30"/>
@@ -76,7 +111,7 @@
     <message>
         <location filename="../wallpaper/intervalcombox.cpp" line="15"/>
         <source>Wallpaper Slideshow</source>
-        <translation>自动更换壁纸</translation>        
+        <translation>自动更换壁纸</translation>
         <extra-child_page>WallpaperSetting</extra-child_page>
         <extra-contents_path>/personalization/WallpaperSetting</extra-contents_path>
     </message>
@@ -186,11 +221,16 @@
     </message>
     <message>
         <location filename="../wallpapersettingplugin.cpp" line="108"/>
+        <source>Fill Style</source>
+        <translation>填充方式</translation>
+    </message>
+    <message>
+        <location filename="../wallpapersettingplugin.cpp" line="109"/>
         <source>Picture</source>
         <translation>图片壁纸</translation>
     </message>
     <message>
-        <location filename="../wallpapersettingplugin.cpp" line="109"/>
+        <location filename="../wallpapersettingplugin.cpp" line="110"/>
         <source>Solid Color</source>
         <translation>纯色壁纸</translation>
     </message>
@@ -198,27 +238,27 @@
 <context>
     <name>dfm_wallpapersetting::WallpaperWindow</name>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="250"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="258"/>
         <source>Select Wallpaper</source>
         <translation>选择壁纸</translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="252"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="260"/>
         <source>Images</source>
         <translation>图片</translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="368"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="376"/>
         <source>Set to lock screen</source>
         <translation>设置锁屏</translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="369"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="377"/>
         <source>Set to desktop</source>
         <translation>设置桌面</translation>
     </message>
     <message>
-        <location filename="../wallpaper/wallpaperwindow.cpp" line="404"/>
+        <location filename="../wallpaper/wallpaperwindow.cpp" line="412"/>
         <source>This system wallpaper is locked. Please contact your admin.</source>
         <translation>当前系统壁纸已被锁定，请联系管理员</translation>
     </message>

--- a/src/dde-control-center-plugins/wallpapersetting/wallpaper/fillstylescombox.cpp
+++ b/src/dde-control-center-plugins/wallpapersetting/wallpaper/fillstylescombox.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fillstylescombox.h"
+
+#include <QComboBox>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+using namespace dfm_wallpapersetting;
+DCORE_USE_NAMESPACE
+
+static constexpr char kConfName[] { "org.deepin.dde.file-manager.desktop" };
+static constexpr char KwallpaperFillStyle[] { "wallpaperFillStyle" };
+
+FillstylesCombox::FillstylesCombox(QFrame *parent)
+    : ComboxWidget(parent)
+{
+    setTitle(tr("Fill Style"));
+    addBackground();
+    QStringList styles;
+    styles << tr("Fill")   // Fill = 0
+           << tr("Fit")   // Fit
+           << tr("Stretch")   // Stretch
+           << tr("Tile")   // Flatten (平铺)
+           << tr("Center");   // Center
+
+    comboBox()->addItems(styles);
+    comboBox()->setCurrentIndex(0);
+    fillStyleConf = DConfig::create("org.deepin.dde.file-manager", kConfName, "", this);
+    connect(this, &ComboxWidget::onIndexChanged, this, &FillstylesCombox::setFillStyle);
+}
+
+FillstylesCombox::~FillstylesCombox()
+{
+}
+
+void FillstylesCombox::reset(const QString &screen, int mode)
+{
+    setVisible(mode != 1);
+    currentScreen = screen;
+
+    if (!fillStyleConf) {
+        qWarning() << "fillStyleConf is null";
+        setVisible(false);
+        return;
+    }
+
+    QString styleConfig = fillStyleConf->value(KwallpaperFillStyle).toString();
+    int style = getValueFromJson(styleConfig, screen);
+    qInfo() << "FillstylesCombox" << mode << "reset" << styleConfig << screen << style;
+    comboBox()->setCurrentIndex(style);
+}
+
+void FillstylesCombox::setFillStyle(int index)
+{
+    if (!fillStyleConf) {
+        qWarning() << "fillStyleConf is null";
+        return;
+    }
+
+    QString jsonStr = fillStyleConf->value(KwallpaperFillStyle).toString();
+    QString newJsonStr = updateJsonValue(jsonStr, currentScreen, index);
+    qInfo() << "setFillStyle" << newJsonStr;
+    fillStyleConf->setValue(KwallpaperFillStyle, newJsonStr);
+}
+
+int FillstylesCombox::getValueFromJson(QString json, const QString &screenName)
+{
+    //The string in dconfig contains extra characters
+    if (json.startsWith('"')) {
+        json.remove(0, 1);
+    }
+    if (json.endsWith('"')) {
+        json.chop(1);
+    }
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(json.toUtf8());
+
+    if (!jsonDoc.isObject())
+        return 0;
+
+    QJsonObject jsonObj = jsonDoc.object();
+
+    if (jsonObj.contains(screenName))
+        return jsonObj[screenName].toInt();
+
+    return 0;
+}
+
+QString FillstylesCombox::updateJsonValue(const QString &jsonStr, const QString &screenName, int value)
+{
+    QString json = jsonStr;
+
+    QJsonDocument jsonDoc;
+    QJsonObject jsonObj;
+
+    if (!json.isEmpty()) {
+        jsonDoc = QJsonDocument::fromJson(json.toUtf8());
+        if (jsonDoc.isObject()) {
+            jsonObj = jsonDoc.object();
+        }
+    }
+
+    // Update or add the screen value
+    jsonObj[screenName] = value;
+
+    // Convert back to string
+    jsonDoc.setObject(jsonObj);
+    return QString::fromUtf8(jsonDoc.toJson(QJsonDocument::Compact));
+}
+
+void FillstylesCombox::onFillStyleChanged(const QString &key)
+{
+    if (key != KwallpaperFillStyle)
+        return;
+
+    QString styleConfig = fillStyleConf->value(kConfName).toString();
+    int style = getValueFromJson(styleConfig, currentScreen);
+    comboBox()->setCurrentIndex(style);
+}

--- a/src/dde-control-center-plugins/wallpapersetting/wallpaper/fillstylescombox.h
+++ b/src/dde-control-center-plugins/wallpapersetting/wallpaper/fillstylescombox.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FILLSTYLESCOMBOX_H
+#define FILLSTYLESCOMBOX_H
+
+#include <widgets/comboxwidget.h>
+#include <DConfig>
+
+namespace dfm_wallpapersetting {
+
+class FillstylesCombox : public dcc::widgets::ComboxWidget
+{
+    Q_OBJECT
+public:
+    explicit FillstylesCombox(QFrame *parent = nullptr);
+    ~FillstylesCombox();
+
+    void reset(const QString &screen, int mode);
+
+public slots:
+    void setFillStyle(int index);
+    void onFillStyleChanged(const QString &key);
+
+private:
+    QString updateJsonValue(const QString &jsonStr, const QString &screenName, int value);
+    int getValueFromJson(QString json, const QString &screenName);
+
+private:
+    DTK_CORE_NAMESPACE::DConfig *fillStyleConf = nullptr;
+    QString currentScreen;
+};
+
+}
+
+#endif   // FILLSTYLESCOMBOX_H

--- a/src/dde-control-center-plugins/wallpapersetting/wallpaper/wallpaperwindow.h
+++ b/src/dde-control-center-plugins/wallpapersetting/wallpaper/wallpaperwindow.h
@@ -11,6 +11,7 @@
 #include "common/listview.h"
 #include "common/itemmodel.h"
 #include "screencombox.h"
+#include "fillstylescombox.h"
 
 #include <QWidget>
 #include <QVBoxLayout>
@@ -58,6 +59,7 @@ private:
     PreviewWidget *preview = nullptr;
     ModeButtonBox *modeBox = nullptr;
     IntervalCombox *intervalCombox = nullptr;
+    FillstylesCombox *fillstylesCombox = nullptr;
     ListView *listView = nullptr;
     ItemModel *itemModel = nullptr;
     ScreenComBox *screenBox = nullptr;

--- a/src/dde-control-center-plugins/wallpapersetting/wallpapersettingplugin.cpp
+++ b/src/dde-control-center-plugins/wallpapersetting/wallpapersettingplugin.cpp
@@ -105,6 +105,7 @@ void WallpaperSettingPlugin::initSearchData()
 
     // wallpaper setting widget
     m_frameProxy->setDetailVisible(module, displayName(), tr("Wallpaper Slideshow"), true);
+    m_frameProxy->setDetailVisible(module, displayName(), tr("Fill Style"), true);
     m_frameProxy->setDetailVisible(module, displayName(), tr("Picture"), true);
     m_frameProxy->setDetailVisible(module, displayName(), tr("Solid Color"), true);
 


### PR DESCRIPTION
Add desktop wallpaper filling method options

Log: Add desktop wallpaper filling method options
Task: https://pms.uniontech.com/task-view-371829.html

## Summary by Sourcery

Add a Fill Style option to the desktop wallpaper settings, allowing users to select and persist per-screen wallpaper fill modes.

New Features:
- Introduce FillstylesCombox widget to let users choose wallpaper fill methods (Fill, Fit, Stretch, Tile, Center)
- Persist per-screen fill style in DConfig as JSON and apply it when loading the wallpaper settings

Enhancements:
- Integrate FillstylesCombox into WallpaperWindow UI and reset logic
- Expose the new Fill Style option in search metadata for wallpaper settings
- Add translation entries for Fill Style and its options in both English and Chinese