### PR TITLE
fix(wallpapersetting): correct fill style behavior when changing screen

### DIFF
--- a/src/dde-control-center-plugins/wallpapersetting/wallpaper/wallpaperwindow.cpp
+++ b/src/dde-control-center-plugins/wallpapersetting/wallpaper/wallpaperwindow.cpp
@@ -119,7 +119,6 @@ void WallpaperWindow::reset(QString screen, int mode)
 
     currentScreen = screen;
     intervalCombox->reset(screen);
-    fillstylesCombox->reset(screen, mode);
     screenBox->setCurrentScreen(screen);
 
     // current wallpaper
@@ -144,7 +143,9 @@ void WallpaperWindow::reset(QString screen, int mode)
 
     qDebug() << "current wallpaper" << cur << isColor << mode;
 
-    modeBox->switchMode(isColor ? ModeButtonBox::SolidColor : ModeButtonBox::Picture);
+    auto currentMode = isColor ? ModeButtonBox::SolidColor : ModeButtonBox::Picture;
+    fillstylesCombox->reset(screen, currentMode);
+    modeBox->switchMode(currentMode);
 
     qDebug() << "wait wallpapers...";
     // wait 500ms for data


### PR DESCRIPTION
- Move fill style reset to after mode determination
- Use currentMode variable to improve code readability and maintain consistency

Log: fix(wallpapersetting): correct fill style behavior when changing screen
Bug: https://pms.uniontech.com/bug-view-323007.html

## Summary by Sourcery

Correct fill style behavior when changing wallpaper screens by resetting fill style after mode determination and improve code readability using a dedicated currentMode variable.

Bug Fixes:
- Defer fill style reset until after determining the current wallpaper mode to ensure correct behavior on screen change.

Enhancements:
- Introduce a currentMode variable for consistency and improved readability in mode handling.