### PR TITLE
feat: add configurable password checkbox display in screensaver settings

### DIFF
--- a/src/dde-control-center-plugins/wallpapersetting/screensaver/idletime.h
+++ b/src/dde-control-center-plugins/wallpapersetting/screensaver/idletime.h
@@ -22,6 +22,8 @@ public:
     static QVector<int> availableTime();
     static QString timeFormat(int second);
     static QStringList translateText(const QVector<int> &list);
+private:
+    bool getShowConfig();
 signals:
     int getCurrentIdle();
     void setCurrentIdle(int sec);


### PR DESCRIPTION
- Add DConfig integration to control password checkbox visibility
- Implement getShowConfig() method to read configuration value
- Conditionally create and show password checkbox based on config
- Add null pointer checks for pwdCheck to prevent crashes
- Emit setIsLock(false) when password checkbox is hidden
- Add necessary DTK Core includes and namespace usage

The password checkbox will now only be displayed when the configuration value "control.center.requirePassword.show" is set to true, providing flexible control over the UI elements in screensaver settings.

Log: add configurable password checkbox display in screensaver settings
Task: https://pms.uniontech.com/task-view-379319.html

## Summary by Sourcery

Make the password checkbox in screensaver settings visibility configurable via DConfig and handle its hidden state safely

New Features:
- Allow toggling the "Require a password on wakeup" checkbox via the DConfig key "control.center.requirePassword.show"

Enhancements:
- Add getShowConfig() to read the configuration value and include necessary DConfig/DtkCore headers
- Conditionally create or hide the password checkbox and emit setIsLock(false) when it’s hidden
- Add null pointer checks around pwdCheck in reset() to prevent crashes